### PR TITLE
Moves the DevOpsDozen Award below the fold

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -6,7 +6,6 @@ import sodr2023thumb from "../assets/sodr-2023-thumb.png";
 import devopsdoz from "../assets/best-devops-research.png";
 import { Button } from "./Button";
 import { Card } from "./Card";
-import { NoTitleCard } from "./NoTitleCard";
 import { faYoutube } from "@fortawesome/free-brands-svg-icons";
 import { Hero } from "./Hero";
 import { SODRHero } from "./SODRHero";
@@ -31,21 +30,6 @@ export const HomePage = () => {
       <Hero />
 
       <Grid container spacing={2} maxWidth={1600} margin="auto" padding="1rem">
-      <Grid item xs={12}>
-          <NoTitleCard
-            imageLeft={devopsdoz}
-            size="l"
-          >
-            DORA's Accelerate State of DevOps Report was selected as the <i>Best
-            DevOps Survey/Analysis/Research</i>, which recognizes “research that has 
-            significantly and positively impacted the DevOps community.”
-            <br />
-            <br />
-            Congratulations to all of 
-            the <a href="https://devopsdozen.com/" target="_devops-dozen">2024 DevOps 
-            Dozen winners</a>!
-          </NoTitleCard>
-        </Grid>
         <Grid item xl={4} md={6} xs={12}>
           <Card title="DORA.dev" imageLeft={doraDevCard} size="s">
             DORA is the largest and longest
@@ -78,7 +62,7 @@ export const HomePage = () => {
           </Card>
         </Grid>
 
-        <Grid item xl={4} xs={12}>
+        <Grid item xl={4} md={6} xs={12}>
           <Card
             title="YouTube Channel"
             iconLeft={faYoutube}
@@ -99,6 +83,23 @@ export const HomePage = () => {
             <Button onClick={handleYoutubeButton} variant="contained" centered>
               Subscribe to Our Channel
             </Button>
+          </Card>
+        </Grid>
+        <Grid item xl={4} md={6} xs={12}>
+        <Card
+            title="Award Winning Research"
+            imageLeft={devopsdoz}
+            iconStyle={{ color: "#d01b1b" }}
+            size="m"
+          >
+            DORA's Accelerate State of DevOps Report was selected as the <i>Best
+            DevOps Survey/Analysis/Research</i>, which recognizes “research that has 
+            significantly and positively impacted the DevOps community.”
+            <br />
+            <br />
+            Congratulations to all of 
+            the <a href="https://devopsdozen.com/" target="_devops-dozen">2024 DevOps 
+            Dozen winners</a>!
           </Card>
         </Grid>
 

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -85,7 +85,7 @@ export const HomePage = () => {
             </Button>
           </Card>
         </Grid>
-        <Grid item xl={4} md={6} xs={12}>
+        <Grid item xs={12}>
         <Card
             title="Award Winning Research"
             imageLeft={devopsdoz}


### PR DESCRIPTION
This puts the DevOpsDozen Award on the same line as the YouTube channel.