### PR TITLE
Fix visual bugs on home page

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -9,7 +9,7 @@ export const Hero = () => {
         <Box>
           <Box display="flex" style={{ backgroundColor: "#f8f9fa" }}>
             <Box display="flex" alignItems="center">
-              <Box>
+              <Box paddingBottom="1rem">
                 <Box p="1rem" fontSize="1.5rem" textAlign="center">
                   The DORA Community provides opportunities to learn, discuss,
                   and collaborate on software delivery and operational

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -33,7 +33,7 @@ export const HomePage = () => {
     <Stack spacing={0}>
       <SiteBanner />
 
-      <Grid container spacing={2} maxWidth={1600} margin="auto" padding="1rem">
+      <Grid container spacing={0} maxWidth={1600} margin="auto" padding="1rem">
         <Grid item xs={12}>
           <Hero />
         </Grid>


### PR DESCRIPTION
Before: 

1. Grid is too big and causes the content to escape the parent container. Known issue with spacing https://github.com/mui/material-ui/issues/7466#issuecomment-316356427 . The solution is to not use this feature.
2. The "Join community..." button is flush to the bottom of the container and 1rem padding is more consistent with look of other items on the page. The solution is to add some bottom padding to the parent element.
![dora community_](https://github.com/user-attachments/assets/eaf044cd-d876-4dba-8345-fa8465c155ca)

After:
![localhost_5173_](https://github.com/user-attachments/assets/9b702d93-fead-4ef9-a569-4dcee84cbbb6)
