### PR TITLE
feat(HomePage): Add in-page linking to sections

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -9,6 +9,8 @@ import { Card } from "./Card";
 import { faYoutube } from "@fortawesome/free-brands-svg-icons";
 import { Hero } from "./Hero";
 import { SiteBanner } from "./SiteBanner";
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
 
 const handleDoraDevButton = () => {
   window.open("https://dora.dev", "_blank");
@@ -27,6 +29,17 @@ const handleGenAIReportButton = () => {
 };
 
 export const HomePage = () => {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (location.hash) {
+      const id = location.hash.substring(1);
+      const element = document.getElementById(id);
+      if (element) {
+        element.scrollIntoView({ behavior: "smooth" });
+      }
+    }
+  }, [location]);
   return (
     <Stack spacing={0}>
       <SiteBanner />
@@ -37,7 +50,7 @@ export const HomePage = () => {
         </Grid>
         <Grid container item spacing={2} justifyContent="center">
 
-          <Grid item xl={4} md={6} xs={12}>
+          <Grid item xl={4} md={6} xs={12} id="dora-dev">
             <Card title="DORA.dev" imageLeft={doraDevCard} size="s">
               DORA is the largest and longest
               running research program of its kind, that seeks to understand the
@@ -51,7 +64,7 @@ export const HomePage = () => {
             </Card>
           </Grid>
 
-          <Grid item xl={4} md={6} xs={12}>
+          <Grid item xl={4} md={6} xs={12} id="merch">
             <Card title="T-shirts" imageLeft={tshirtCard} size="s">
             Limited-edition DORA tees are here! Multiple colors, straight cut &
             fitted styles. Get yours before they disappear!
@@ -71,7 +84,7 @@ export const HomePage = () => {
 
         </Grid>
 
-        <Grid container item spacing={2} justifyContent="center">
+        <Grid container item spacing={2} justifyContent="center" id="gen-ai-report">
           <Grid item xl={4} md={6} xs={12}>
             <Card
               title="Impact of Generative AI"
@@ -92,7 +105,7 @@ export const HomePage = () => {
             </Card>
           </Grid>
 
-          <Grid item xl={4} md={6} xs={12}>
+          <Grid item xl={4} md={6} xs={12} id="youtube">
             <Card
               title="YouTube Channel"
               iconLeft={faYoutube}
@@ -118,9 +131,9 @@ export const HomePage = () => {
           </Grid>
         </Grid>
 
-        <Grid item xs={12}>
+        <Grid item xs={12} id="calendar">
           <Card title="Calendar">
-            <Box display="flex" justifyContent="center" id="test">
+            <Box display="flex" justifyContent="center">
               <Box
                 position="relative"
                 overflow="hidden"

--- a/test/playwright/tests/HomePage.spec.ts
+++ b/test/playwright/tests/HomePage.spec.ts
@@ -39,3 +39,19 @@ for (const [buttonName, expectedURL] of Object.entries(buttonTests)) {
 test('Homepage displays a calendar iframe', async ({ page }) => {
   await expect(page.locator('iframe[src*="calendar.google.com"]')).toBeVisible();
 });
+
+test.describe('scrolling with a URL hash', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/#calendar');
+  });
+
+  test('should put the calendar in the viewport', async ({ page }) => {
+    const calendarCard = page.locator('#calendar');
+    await expect(calendarCard).toBeInViewport();
+  });
+
+  test('should move the dora-dev card out of the viewport', async ({ page }) => {
+    const doraDevCard = page.locator('#dora-dev');
+    await expect(doraDevCard).not.toBeInViewport();
+  });
+});


### PR DESCRIPTION
Adds the ability to link directly to sections on the home page.

This is accomplished by using a `useEffect` hook that checks for a URL hash on page load. If a hash is present, the page scrolls to the element with the corresponding ID.

This improves user experience by allowing users to navigate directly to specific content, such as the community calendar, via a shared URL.

Preview links:
* https://deploy-preview-143--dora-community.netlify.app/#calendar
* https://deploy-preview-143--dora-community.netlify.app/#youtube
* https://deploy-preview-143--dora-community.netlify.app/#dora-dev